### PR TITLE
Remove restriction on extending property accessors and method resolvers

### DIFF
--- a/lib/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/expression/ThymeleafEvaluationContext.java
+++ b/lib/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/expression/ThymeleafEvaluationContext.java
@@ -239,17 +239,11 @@ public final class ThymeleafEvaluationContext
 
     @Override
     public List<MethodResolver> getMethodResolvers() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getMethodResolvers();
-        }
         return super.getMethodResolvers();
     }
 
     @Override
     public List<PropertyAccessor> getPropertyAccessors() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getPropertyAccessors();
-        }
         return super.getPropertyAccessors();
     }
 

--- a/lib/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/expression/ThymeleafEvaluationContextWrapper.java
+++ b/lib/thymeleaf-spring5/src/main/java/org/thymeleaf/spring5/expression/ThymeleafEvaluationContextWrapper.java
@@ -149,16 +149,10 @@ public final class ThymeleafEvaluationContextWrapper implements IThymeleafEvalua
     }
 
     public List<MethodResolver> getMethodResolvers() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getMethodResolvers();
-        }
         return this.methodResolvers == null ? this.delegate.getMethodResolvers() : this.methodResolvers;
     }
 
     public List<PropertyAccessor> getPropertyAccessors() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getPropertyAccessors();
-        }
         return this.propertyAccessors == null ? this.delegate.getPropertyAccessors() : this.propertyAccessors;
     }
 

--- a/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/expression/ThymeleafEvaluationContext.java
+++ b/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/expression/ThymeleafEvaluationContext.java
@@ -239,17 +239,11 @@ public final class ThymeleafEvaluationContext
 
     @Override
     public List<MethodResolver> getMethodResolvers() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getMethodResolvers();
-        }
         return super.getMethodResolvers();
     }
 
     @Override
     public List<PropertyAccessor> getPropertyAccessors() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getPropertyAccessors();
-        }
         return super.getPropertyAccessors();
     }
 

--- a/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/expression/ThymeleafEvaluationContextWrapper.java
+++ b/lib/thymeleaf-spring6/src/main/java/org/thymeleaf/spring6/expression/ThymeleafEvaluationContextWrapper.java
@@ -149,16 +149,10 @@ public final class ThymeleafEvaluationContextWrapper implements IThymeleafEvalua
     }
 
     public List<MethodResolver> getMethodResolvers() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getMethodResolvers();
-        }
         return this.methodResolvers == null ? this.delegate.getMethodResolvers() : this.methodResolvers;
     }
 
     public List<PropertyAccessor> getPropertyAccessors() {
-        if (this.variableAccessRestricted) {
-            return this.restrictedModeContext.getPropertyAccessors();
-        }
         return this.propertyAccessors == null ? this.delegate.getPropertyAccessors() : this.propertyAccessors;
     }
 


### PR DESCRIPTION
Remove the `variableAccessRestricted` check in `getMethodResolvers()` and `getPropertyAccessors()` so that
custom property accessors and method resolvers can be added even when variable access restriction is enabled.

The variable access restriction is already enforced at the variable access level, so this change does not affect security.